### PR TITLE
chore: check for wdioService cap in multiremote browser

### DIFF
--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -44,7 +44,7 @@ export function getBrowserCapabilities(browser: Browser<'async'> | MultiRemoteBr
  * @param cap browser capabilities
  */
 export function isBrowserstackCapability(cap?: Capabilities.Capabilities) {
-    return Boolean(cap && cap['bstack:options'])
+    return Boolean(cap && cap['bstack:options'] && Object.keys(cap['bstack:options']).length && !(Object.keys(cap['bstack:options']).length === 1 && cap['bstack:options'].wdioService))
 }
 
 export function getParentSuiteName(fullTitle: string, testSuiteTitle: string): string {

--- a/packages/wdio-browserstack-service/tests/util.test.ts
+++ b/packages/wdio-browserstack-service/tests/util.test.ts
@@ -123,12 +123,20 @@ describe('getBrowserDescription', () => {
 })
 
 describe('isBrowserstackCapability', () => {
-    it('should detect browserstack W3C capabilities', () => {
+    it('should return false if browserstack W3C capabilities is absent or not valid', () => {
         expect(isBrowserstackCapability({})).toBe(false)
         expect(isBrowserstackCapability()).toBe(false)
         // @ts-expect-error test invalid params
         expect(isBrowserstackCapability({ 'bstack:options': null })).toBe(false)
-        expect(isBrowserstackCapability({ 'bstack:options': {} })).toBe(true)
+        expect(isBrowserstackCapability({ 'bstack:options': {} })).toBe(false)
+    })
+
+    it('should return false if only key in browserstack W3C capabilities is wdioService', () => {
+        expect(isBrowserstackCapability({ 'bstack:options': { wdioService: 'version' } })).toBe(false)
+    })
+
+    it('should detect browserstack W3C capabilities', () => {
+        expect(isBrowserstackCapability({ 'bstack:options': { os: 'some os' } })).toBe(true)
     })
 })
 


### PR DESCRIPTION
## Proposed changes

handle case where bstackOptions in caps causes issues with multiremote

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
